### PR TITLE
Added plaintext response to return maximum of coinsupply via REST-API

### DIFF
--- a/endpoints/get_circulating_supply.py
+++ b/endpoints/get_circulating_supply.py
@@ -46,3 +46,13 @@ async def get_total_coins():
     """
     resp = await karlsend_client.request("getCoinSupplyRequest")
     return str(float(resp["getCoinSupplyResponse"]["circulatingSompi"]) / 100000000)
+
+
+@app.get("/info/coinsupply/max", tags=["Karlsen network info"],
+         response_class=PlainTextResponse)
+async def get_max_coins():
+    """
+    Get maximum amount of $KLS token as numerical value
+    """
+    resp = await karlsend_client.request("getCoinSupplyRequest")
+    return str(float(resp["getCoinSupplyResponse"]["maxSompi"]) / 100000000)

--- a/endpoints/get_circulating_supply.py
+++ b/endpoints/get_circulating_supply.py
@@ -28,7 +28,7 @@ async def get_coinsupply():
          response_class=PlainTextResponse)
 async def get_circulating_coins(in_billion : bool = False):
     """
-    Get circulating amount of $KLS token as numerical value
+    Get circulating amount of $KLS coin as numerical value
     """
     resp = await karlsend_client.request("getCoinSupplyRequest")
     coins = str(float(resp["getCoinSupplyResponse"]["circulatingSompi"]) / 100000000)
@@ -42,7 +42,7 @@ async def get_circulating_coins(in_billion : bool = False):
          response_class=PlainTextResponse)
 async def get_total_coins():
     """
-    Get total amount of $KLS token as numerical value
+    Get total amount of $KLS coin as numerical value
     """
     resp = await karlsend_client.request("getCoinSupplyRequest")
     return str(float(resp["getCoinSupplyResponse"]["circulatingSompi"]) / 100000000)
@@ -52,7 +52,7 @@ async def get_total_coins():
          response_class=PlainTextResponse)
 async def get_max_coins():
     """
-    Get maximum amount of $KLS token as numerical value
+    Get maximum amount of $KLS coin as numerical value
     """
     resp = await karlsend_client.request("getCoinSupplyRequest")
     return str(float(resp["getCoinSupplyResponse"]["maxSompi"]) / 100000000)


### PR DESCRIPTION
Recently we've discussed an integration and question about "How to get maximum supply with single API call?" appeared. We have already `/info/coinsupply` to get this information as JSON response. We also have `/info/coinsupply/circulating` and `/info/coinsupply/total` to get amount as plaintext response of `circulating` and `total`; `circulating = total - locked` which is the same amount in Karlsen Network.

However we didn't have such plaintext API response for `max` and this pull request adds it via `/info/coinsupply/max` and closes #4. It is running already in `testnet-1` and documentation can be found at:

https://api.testnet-1.karlsencoin.com/docs#/Karlsen%20network%20info/get_max_coins_info_coinsupply_max_get

It can be tested with:

https://api.testnet-1.karlsencoin.com/info/coinsupply/max

Beside this, we've also fixed documentation of the relevant API calls, Karlsen is a layer 1 chain with coins and no tokens.